### PR TITLE
update docs and examples

### DIFF
--- a/website/docs/d/oraclepaas_database_service_instance.html.markdown
+++ b/website/docs/d/oraclepaas_database_service_instance.html.markdown
@@ -3,7 +3,7 @@ layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_service_instance"
 sidebar_current: "docs-oraclepaas-datasource-database-service-instance"
 description: |-
-  Gets information about the configuration of a Database Service Instance inside an Oracle PaaS Cloud environment.
+  Gets information about the configuration of an Oracle Database Cloud Service instance on the Oracle Cloud Platform.
 ---
 
 # oraclepaas\_database\_service\_instance
@@ -14,7 +14,7 @@ Use this data source to access the configuration of a Database Service Instance
 
 ```hcl
 data "oraclepaas_database_service_instance" "foo" {
-  name = "dbServiceInstance1"
+  name = "database-service-instance-1"
 }
 
 output "region" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,45 +1,44 @@
 ---
 layout: "oraclepaas"
-page_title: "Provider: Oracle Platform Cloud"
+page_title: "Provider: Oracle Cloud Platform"
 sidebar_current: "docs-oraclepaas-index"
 description: |-
-  The Oracle Platform provider is used to interact with the many resources supported by the Oracle Platform Cloud. The provider needs to be configured with credentials for the Oracle Platform Cloud API.
+  The Oracle Cloud Platform (Oracle PaaS) provider is used to interact with resources supported by the Oracle Cloud Platform services. The provider needs to be configured with credentials for the Oracle Cloud Account.
 ---
 
-# Oracle Platform Cloud Provider
+# Oracle Cloud Platform Provider
 
-The Oracle Platform Cloud provider is used to interact with the many resources supported by the Oracle Platform Cloud.
-The provider needs to be configured with credentials for the Oracle Platform Cloud API.
+The Oracle Cloud Platform (Oracle PaaS) provider is used to interact with resources supported by the [Oracle Cloud Platform](http://cloud.oracle.com/paas) services. The provider needs to be configured with credentials for the Oracle Cloud Account.
 
 Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
 ```hcl
-# Configure the Oracle Platform Cloud
+# Configure the Oracle Cloud Platform provider
 provider "oraclepaas" {
   user              = "..."
   password          = "..."
   identity_domain   = "..."
   database_endpoint = "..."
+  java_endpoint     = "..."
 }
 
 # Create a Database Service Instance
 resource "oraclepaas_database_service_instance" "default" {
-  name        = "default-service-instance"
-  description = "default-service-instance"
-  edition = "EE"
-  level = "PAAS"
-  shape = "oc3"
+  name              = "default-service-instance"
+  description       = "default-service-instance"
+  edition           = "EE"
+  shape             = "oc1m"
   subscription_type = "HOURLY"
-  version = "12.2.0.1"
-  ssh_public_key = "ssh key"
+  version           = "12.2.0.1"
+  ssh_public_key    = "ssh key"
 
   database_configuration {
-    admin_password = "Test_String7"
+    admin_password     = "Pa55_Word"
+    sid                = "ORCL"
     backup_destination = "NONE"
-    sid = "ORCL"
-    usable_storage = 15
+    usable_storage     = 15
   }
 }
 ```
@@ -56,16 +55,16 @@ The following arguments are supported:
 
 * `identity_domain` - (Optional) The Identity Domain or Service Instance ID of the environment to use. It can also be sourced from the `OPC_IDENTITY_DOMAIN` environment variable.  
 
-* `database_endpoint` - (Optional) The database API endpoint to use, associated with your Oracle Platform Cloud account.
+* `database_endpoint` - (Optional) The database API endpoint to use, associated with your Oracle Cloud Platform account.
 This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the
 `ORACLEPAAS_DATABASE_ENDPOINT` environment variable.
 
-* `java_endpoint` - (Optional) The java API endpoint to use, associated with your Oracle Platform Cloud Account.
+* `java_endpoint` - (Optional) The java API endpoint to use, associated with your Oracle Cloud Platform Account.
 This is known as the `REST Endpoint` within the Oracle portal. It can also be sourced from the
 `ORACLEPAAS_JAVA_ENDPOINT` environment variable.
 
 * `max_retries` - (Optional) The maximum number of tries to make for a successful response when operating on
-resources within Oracle Platform Cloud. It can also be sourced from the `OPC_MAX_RETRIES` environment variable.
+resources within Oracle Cloud Platform. It can also be sourced from the `OPC_MAX_RETRIES` environment variable.
 Defaults to 1.
 
 * `insecure` - (Optional) Skips TLS Verification for using self-signed certificates. Should only be used if

--- a/website/docs/r/oraclepaas_database_access_rule.html.markdown
+++ b/website/docs/r/oraclepaas_database_access_rule.html.markdown
@@ -3,29 +3,28 @@ layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_access_rule"
 sidebar_current: "docs-oraclepaas-resource-access-rule"
 description: |-
-  Creates and manages a database access rule in an oraclepaas identity domain.
+  Creates and manages a Database Access Rule for an Oracle Database Cloud service instance.
 
 ---
 
 # oraclepaas_database_access_rule
 
-The oraclepaas_database_access_rule` resource creates and manages a database access rule inside
-Oracle PaaS Cloud
+The `oraclepaas_database_access_rule` resource creates and manages a Database Access Rule for an Oracle Database Cloud service instance.
 
 ## Example Usage
 
 ```hcl
 resource "oraclepaas_database_service_instance" "default" {
-  name        = "service-instance-1"
+  name = "database-service-instance-1"
   ...
 }
 
 resource "oraclepaas_database_access_rule" "default" {
-	name = "test-access-rule-%d"
+	name                = "example-access-rule"
 	service_instance_id = "${oraclepaas_database_service_instance.default.name}"
-	description = "default-access-rule"
-	ports = "8000"
-	source = "PUBLIC-INTERNET"
+	description         = "enable port 8000"
+	ports               = "8000"
+	source              = "PUBLIC-INTERNET"
 }
 ```
 

--- a/website/docs/r/oraclepaas_database_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_database_service_instance.html.markdown
@@ -3,33 +3,37 @@ layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_service_instance"
 sidebar_current: "docs-oraclepaas-resource-service-instance"
 description: |-
-  Creates and manages a service instance in an oraclepaas identity domain.
+  Creates and manages an Oracle Database Cloud Service instance on the Oracle Cloud Platform.
 
 ---
 
 # oraclepaas\_database\_service\_instance
 
-The ``oraclepaas_database_service_instance`` resource creates and manages a database service instance inside
-Oracle PaaS Cloud
+The `oraclepaas_database_service_instance` resource creates and manages a an Oracle Database Cloud Service instance on the Oracle Cloud Platform.
 
 ## Example Usage
 
 ```hcl
 resource "oraclepaas_database_service_instance" "default" {
-  name        = "service-instance-1"
+  name        = "database-service-instance"
   description = "This is a description for an service instance"
-  edition = "EE_EP"
-  level = "PAAS"
-  shape = "oc1m"
+
+  edition           = "EE"
+  shape             = "oc1m"
   subscription_type = "HOURLY"
-  version = "12.2.0.1"
-  vm_public_key = "An ssh public key"
-  
+  version           = "12.2.0.1"
+  vm_public_key     = "An ssh public key"
+
   database_configuration {
-      admin_password = "Test_String7"
+      admin_password     = "Pa55_Word"
+      sid                = "BOTH"
       backup_destination = "NONE"
-      sid = "ORCL"
-      usable_storage = 15
+      usable_storage     = 15
+  }
+
+  backups {
+      cloud_storage_container = "Storage-${var.domain}/database-service-instance-backup"
+      auto_generate = true
   }
 }
 ```
@@ -57,7 +61,7 @@ The following arguments are supported:
 * `default_access_rules` - (Optional) Specifies the details on which default access rules are enable or disabled. Default Access Rules
 are configured below.
 
-* `instantiate_from_backup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database 
+* `instantiate_from_backup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database
 stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Instantiate from Backup is documented below.
 
 * `ip_network` - (Optional) This attribute is only applicable to accounts where regions are supported. The three-part name of an IP network to which the service instance is added. For example: /Compute-identity_domain/user/object
@@ -80,7 +84,7 @@ Default value is `false`.
 
 * `region` - (Optional) Specifies the location where the service instance is provisioned (only for accounts where regions are supported).
 
-* `standby` - (Optional) Specifies the configuration details of the standby database. This is only applicable in Oracle Cloud Infrastructure Regions. `failover_database` and 
+* `standby` - (Optional) Specifies the configuration details of the standby database. This is only applicable in Oracle Cloud Infrastructure Regions. `failover_database` and
 `disaster_recovery` inside the `database_configuration` block must be set to `true`. Standby is documented below.
 
 * `subnet` - (Optional) Name of the subnet within the region where the Oracle Database Cloud Service instance is to be provisioned.
@@ -100,13 +104,13 @@ Database Configuration supports the following:
 * `disaster_recovery` - (Optional) Specify if an Oracle Data Guard configuration is created using the Disaster Recovery option or the High Availability option.
 Default value is `false`.
 
-* `failover_database` - (Optional) Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created. 
+* `failover_database` - (Optional) Specify if an Oracle Data Guard configuration comprising a primary database and a standby database is created.
 Default value is `false`.
 
-* `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance. 
+* `golden_gate` - (Optional) Specify if the database should be configured for use as the replication database of an Oracle GoldenGate Cloud Service instance.
 You cannot set `goldenGate` to `true` if either `is_rac` or `failoverDatabase` is set to `true`. Default value is `false`.
 
-* `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured. 
+* `is_rac` - (Optional) Specify if a cluster database using Oracle Real Application Clusters should be configured.
 Default value is `false`.
 
 * `national_character_set` - (Optional) National Character Set for the Database Cloud Service instance. Valid values are `AL16UTF16` and `UTF8`.
@@ -168,7 +172,7 @@ Instantiate from Backup supports the following:
 * `on_premise` - (Optional) Specify if the existing cloud backup being used to replace the database is from an on-premises database or another Database Cloud Service instance.
 The default value is false.
 
-* `service_id` - (Optional) Oracle Database Cloud Service instance name from which the database of new Oracle Database Cloud Service instance should be created. This value is required if 
+* `service_id` - (Optional) Oracle Database Cloud Service instance name from which the database of new Oracle Database Cloud Service instance should be created. This value is required if
 `on_premise` is set to true.
 
 * `wallet_file_content` - (Optional) String containing the xsd:base64Binary representation of the cloud backup's wallet file. This wallet is used to decrypt the backup. Specify either `ibkup_decryption_key` or `ibkup_wallet_file_content` for decrypting the backup.
@@ -186,7 +190,7 @@ Use the following format to specify the container name: `<storageservicename>-<s
 
 Hybrid Disaster Recovery supports the following:
 
-* `cloud_storage_container` - (Required) Name of the Oracle Storage Cloud Service container where the backup from on-premise instance is stored. 
+* `cloud_storage_container` - (Required) Name of the Oracle Storage Cloud Service container where the backup from on-premise instance is stored.
 Use the following format to specify the container name: `<storageservicename>-<storageidentitydomain>/<containername>`
 
 * `cloud_storage_username` - (Required) Username for the Oracle Storage Cloud Service administrator.

--- a/website/docs/r/oraclepaas_java_access_rule.html.markdown
+++ b/website/docs/r/oraclepaas_java_access_rule.html.markdown
@@ -3,29 +3,28 @@ layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_java_access_rule"
 sidebar_current: "docs-oraclepaas-resource-access-rule"
 description: |-
-  Creates and manages a java access rule in an oraclepaas identity domain.
+  Creates and manages an Access Rule for an Java Cloud service instance.
 
 ---
 
 # oraclepaas_java_access_rule
 
-The oraclepaas_java_access_rule` resource creates and manages a java access rule inside
-Oracle PaaS Cloud
+The `oraclepaas_java_access_rule` resource creates and manages an Access Rule for an Java Cloud service instance.
 
 ## Example Usage
 
 ```hcl
 resource "oraclepaas_java_service_instance" "default" {
-  name        = "service-instance-1"
+  name        = "java-service-instance-1"
   ...
 }
 
 resource "oraclepaas_java_access_rule" "default" {
-	name = "test-access-rule-%d"
+	name                = "example-access-rule"
 	service_instance_id = "${oraclepaas_java_service_instance.default.name}"
-	description = "default-access-rule"
-	ports = "8000"
-	source = "PUBLIC-INTERNET"
+	description         = "enable port 8000"
+	ports               = "8000"
+	source              = "PUBLIC-INTERNET"
 }
 ```
 

--- a/website/docs/r/oraclepaas_java_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_java_service_instance.html.markdown
@@ -3,13 +3,13 @@ layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_java_service_instance"
 sidebar_current: "docs-oraclepaas-resource-service-instance"
 description: |-
-  Creates and manages a java service instance in an Oracle PaaS identity domain.
+  Creates and manages an Oracle Java Cloud Service instance on the Oracle Cloud Platform.
 
 ---
 
 # oraclepaas_java_service_instance
 
-The ``oraclepaas_java_service_instance`` resource creates and manages a java service instance in an Oracle PaaS identity domain.
+The `oraclepaas_java_service_instance` resource creates and manages an Oracle Java Cloud Service instance on the Oracle Cloud Platform.
 
 ## Example Usage
 
@@ -19,27 +19,28 @@ resource "oraclepaas_database_service_instance" "default" {
 }
 
 resource "oraclepaas_java_service_instance" "default" {
-    name = "test-java-service-instance-%d"
-    edition = "SUITE"
-    service_version = "12cRelease212"
-    ssh_public_key = "ssh-rsa public_key"
-    force_delete = true	
-    weblogic_server {
-        shape = "oc3"
-        database {
-            name = "${oraclepaas_database_service_instance.test.name}"
-            username = "sys"
-            password = "Test_String7"
-        }
-        admin {
-            username = "terraform-user"
-            password = "Test_String7"
-        }
+  name            = "java-service-instance"
+  edition         = "EE"
+  service_version = "12cRelease212"
+  ssh_public_key  = "ssh-rsa public_key"
+
+  weblogic_server {
+    shape = "oc3"
+    database {
+      name     = "${oraclepaas_database_service_instance.test.name}"
+      username = "sys"
+      password = "Pa55_word"
     }
-    cloud_storage {
-        container = "Storage-%s/acctest-%d"
-        auto_generate = true
+    admin {
+      username = "weblogic"
+      password = "Weblogic_1"
     }
+  }
+
+  backups {
+    cloud_storage_container = "Storage-${var.domain}/java-service-instance-backup"
+    auto_generate = true
+  }
 }
 ```
 
@@ -51,33 +52,36 @@ resource "oraclepaas_database_service_instance" "default" {
 }
 
 resource "oraclepaas_java_service_instance" "default" {
-    name = "java-service-instance-otd"
-  	edition = "SUITE"
-  	service_version = "12cRelease212"
-    ssh_public_key = "ssh-key"
-  	weblogic_server {
-  		shape = "oc3"
-  		database {
-  			name = "${oraclepaas_database_service_instance.test.name}"
-  			username = "sys"
-  			password = "Test_String7"
-  		}
-  		admin {
-  			username = "terraform-user"
-  			password = "Test_String7"
-  		}
-  	}
-  	cloud_storage {
-  		container = "Storage-%s/acctest-%d"
-  		auto_generate = true
-  	}
-  	otd {
-  		admin {
-  			username = "terraform-user"
-  			password = "Test_String7"
-  		}
-  		shape = "oc1m"
-  	}
+  name            = "java-service-instance-otd"
+  edition         = "EE"
+  service_version = "12cRelease212"
+  ssh_public_key  = "ssh-rsa public_key"
+  weblogic_server {
+    shape = "oc1m"
+    managed_servers {
+      server_count = 2
+    }
+    database {
+      name     = "${oraclepaas_database_service_instance.test.name}"
+      username = "sys"
+      password = "Pa55_Word"
+    }
+    admin {
+      username = "weblogic"
+      password = "Weblogic_1"
+    }
+  }
+  oracle_traffic_director {
+    shape = "oc1m"
+    admin {
+      username = "weblogic"
+      password = "Weblogic_1"
+    }
+    backups {
+    	cloud_storage_container = "Storage-${var.domain}/java-service-instance-otd-backup"
+    	auto_generate = true
+    }
+  }
 }
 ```
 
@@ -96,14 +100,14 @@ is documented below
 
 * `metering_frequency` - (Optional) Billing unit. Possible values are `HOURLY` or `MONTHLY`. Default value is `HOURLY`.
 
-* `availability_domain` - (Optional) Name of a data center location in the Oracle Cloud Infrastructure region that is specified in region. This is 
+* `availability_domain` - (Optional) Name of a data center location in the Oracle Cloud Infrastructure region that is specified in region. This is
 only available for OCI.
 
 * `snapshot_name` - (Optional) Name of the snapshot to clone from.
 
 * `source_service_name` - (Optional) Name of the existing Oracle Java Cloud Service instance that has the snapshot from which you are creating a clone.
 
-* `subnet` - (Optional) A subdivision of a cloud network that is set up in the data center as specified in availabilityDomain. 
+* `subnet` - (Optional) A subdivision of a cloud network that is set up in the data center as specified in availabilityDomain.
 This is only available for OCI.
 
 * `use_identity_service` - (Optional) Flag that specifies whether to use Oracle Identity Cloud Service (true) or the local WebLogic identity store
@@ -161,7 +165,7 @@ is documented below.
 
 * `admin` - (Required) Admin information for the WebLogic Server. Admin is documented below.
 
-* `application_database` - (Optional) Details of Database Cloud Service database deployments that host application 
+* `application_database` - (Optional) Details of Database Cloud Service database deployments that host application
 schemas. Multiple can be specified. Application Database is specified below.
 
 * `backup_volume_size` - (Optional) Size of the backup volume for the service. The value must be a multiple of GBs.

--- a/website/oraclepaas.erb
+++ b/website/oraclepaas.erb
@@ -6,7 +6,7 @@
                     <a href="/docs/providers/index.html">All Providers</a>
                 </li>
                 <li<%= sidebar_current("docs-oraclepaas-index") %>>
-                    <a href="/docs/providers/oraclepaas/index.html">Oracle PaaS Provider</a>
+                    <a href="/docs/providers/oraclepaas/index.html">Oracle Cloud Platform Provider</a>
                 </li>
                 <li<%= sidebar_current("docs-oraclepaas-datasource") %>>
                 <a href="#">PaaS Data Sources</a>


### PR DESCRIPTION
Updates doc with consistent "Oracle Cloud Platform" naming, and cleans up some of the examples.