### PR TITLE
Ability to update shape for database service instance

### DIFF
--- a/oraclepaas/resource_database_service_instance.go
+++ b/oraclepaas/resource_database_service_instance.go
@@ -690,7 +690,7 @@ func resourceOPAASDatabaseServiceInstanceUpdate(d *schema.ResourceData, meta int
 
 		_, err := client.UpdateServiceInstance(updateInput)
 		if err != nil {
-			return fmt.Errorf("Unable to update Service Instance %q: %+v\n%+v %+v %+v", d.Id(), err, updateInput, old, new)
+			return fmt.Errorf("Unable to update Service Instance %q: %+v", d.Id(), err)
 		}
 	}
 

--- a/oraclepaas/resource_database_service_instance_test.go
+++ b/oraclepaas/resource_database_service_instance_test.go
@@ -100,6 +100,36 @@ func TestAccOPAASDatabaseServiceInstance_DefaultAccessRule(t *testing.T) {
 	})
 }
 
+func TestAccOPAASDatabaseServiceInstance_UpdateShape(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDatabaseServiceInstanceBasic(ri)
+	config2 := testAccDatabaseServiceInstanceUpdateShape(ri)
+	resourceName := "oraclepaas_database_service_instance.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseServiceInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttr(
+						resourceName, "shape", "oc3"),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttr(
+						resourceName, "shape", "oc4"),
+				),
+			},
+		},
+	})
+}
+
 // An OCI account is need to test this
 /*
 func TestAccOPAASDatabaseServiceInstance_HDG(t *testing.T) {
@@ -171,6 +201,26 @@ func testAccDatabaseServiceInstanceBasic(rInt int) string {
     edition = "EE"
     level = "PAAS"
     shape = "oc3"
+    subscription_type = "HOURLY"
+    version = "12.2.0.1"
+    ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+
+	database_configuration {
+		admin_password = "Test_String7"
+		backup_destination = "NONE"
+		sid = "ORCL"
+		usable_storage = 15
+	}
+  }`, rInt)
+}
+
+func testAccDatabaseServiceInstanceUpdateShape(rInt int) string {
+	return fmt.Sprintf(`resource "oraclepaas_database_service_instance" "test" {
+    name        = "test-service-instance-%d"
+    description = "test service instance"
+    edition = "EE"
+    level = "PAAS"
+    shape = "oc4"
     subscription_type = "HOURLY"
     version = "12.2.0.1"
     ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
@@ -5,7 +5,6 @@
 // but the Operation body parameter changes from `update` to `delete`.
 // All other parameters for the resource, aside from Status should be ForceNew.
 // The READ function for the AccessRule resource is tricky, as there is
-// no exposed `GET` function on the AccessRule API.
 // There is an API endpoint to view "all" rules, however, which will be used as a
 // data source to match on a supplied AccessRule name.
 // Timeout only supported for the CREATE method

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,42 +256,42 @@
 		{
 			"checksumSHA1": "V2I+dnQYydk9xDUzOqG57xQ3p7g=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "f1005d4c205402a742419a6d49529f20e5a2eec5",
+			"revisionTime": "2018-04-18T16:05:42Z",
+			"version": "v0.9.1",
+			"versionExact": "v0.9.1"
 		},
 		{
-			"checksumSHA1": "ew84cCBLjo4a2ukgn9QAmokvPtI=",
+			"checksumSHA1": "DLtKfRaFfJyHBtMdsNXgURiA5Is=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "f1005d4c205402a742419a6d49529f20e5a2eec5",
+			"revisionTime": "2018-04-18T16:05:42Z",
+			"version": "v0.9.1",
+			"versionExact": "v0.9.1"
 		},
 		{
 			"checksumSHA1": "gVf0q0ZcdNA/1UiXXPY6ThgVAyE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "f1005d4c205402a742419a6d49529f20e5a2eec5",
+			"revisionTime": "2018-04-18T16:05:42Z",
+			"version": "v0.9.1",
+			"versionExact": "v0.9.1"
 		},
 		{
 			"checksumSHA1": "+hIqBzIjhSiGLfgBD2g3gBTDN9M=",
 			"path": "github.com/hashicorp/go-oracle-terraform/java",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "f1005d4c205402a742419a6d49529f20e5a2eec5",
+			"revisionTime": "2018-04-18T16:05:42Z",
+			"version": "v0.9.1",
+			"versionExact": "v0.9.1"
 		},
 		{
 			"checksumSHA1": "NuObCk0/ybL3w++EnltgrB1GQRc=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "f1005d4c205402a742419a6d49529f20e5a2eec5",
+			"revisionTime": "2018-04-18T16:05:42Z",
+			"version": "v0.9.1",
+			"versionExact": "v0.9.1"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",
@@ -683,5 +683,5 @@
 			"revisionTime": "2017-08-04T00:04:37Z"
 		}
 	],
-	"rootPath": "github.com/hashicorp/terraform-provider-oraclepaas"
+	"rootPath": "github.com/terraform-providers/terraform-provider-oraclepaas"
 }


### PR DESCRIPTION
This PR lets users update the shape of their database service instance 


```
make testacc TEST=./oraclepaas TESTARGS="-run=TestAccOPAASDatabaseServiceInstance_UpdateShape"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./oraclepaas -v -run=TestAccOPAASDatabaseServiceInstance_UpdateShape -timeout 180m
=== RUN   TestAccOPAASDatabaseServiceInstance_UpdateShape
--- PASS: TestAccOPAASDatabaseServiceInstance_UpdateShape (3203.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-oraclepaas/oraclepaas	3203.934s
```