### PR TITLE
F db desired state

### DIFF
--- a/oraclepaas/resource_database_service_instance.go
+++ b/oraclepaas/resource_database_service_instance.go
@@ -497,6 +497,10 @@ func resourceOraclePAASDatabaseServiceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"uri": {
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -623,6 +627,7 @@ func resourceOPAASDatabaseServiceInstanceRead(d *schema.ResourceData, meta inter
 	d.Set("cloud_storage_container", result.CloudStorageContainer)
 	d.Set("compute_site_name", result.ComputeSiteName)
 	d.Set("connect_descriptor", result.ConnectDescriptor)
+	d.Set("desired_state", d.Get("desired_state"))
 	d.Set("dbaas_monitor_url", result.DBAASMonitorURL)
 	d.Set("edition", result.Edition)
 	d.Set("em_url", result.EMURL)
@@ -638,6 +643,7 @@ func resourceOPAASDatabaseServiceInstanceRead(d *schema.ResourceData, meta inter
 	d.Set("uri", result.URI)
 	d.Set("shape", result.Shape)
 	d.Set("sid", result.SID)
+	d.Set("status", result.Status)
 	d.Set("subnet", result.Subnet)
 	d.Set("subscription_type", result.SubscriptionType)
 	d.Set("timezone", result.Timezone)
@@ -693,15 +699,15 @@ func resourceOPAASDatabaseServiceInstanceUpdate(d *schema.ResourceData, meta int
 	}
 	client := dbClient.ServiceInstanceClient()
 
-	if old, new := d.GetChange("desired_state"); old.(string) != "" && old.(string) != new.(string) {
+	if d.HasChange("desired_state") {
 		updateInput := &database.DesiredStateInput{
 			Name:           d.Id(),
-			LifecycleState: database.ServiceInstanceLifecycleState(new.(string)),
+			LifecycleState: database.ServiceInstanceLifecycleState(d.Get("desired_state").(string)),
 		}
 
 		_, err := client.UpdateDesiredState(updateInput)
 		if err != nil {
-			return fmt.Errorf("Unable to update Service Instance %q: %+v\n%+v %+v %+v", d.Id(), err, updateInput, old, new)
+			return fmt.Errorf("Unable to update Service Instance %q: %+v", d.Id(), err)
 		}
 	}
 

--- a/oraclepaas/resource_database_service_instance_test.go
+++ b/oraclepaas/resource_database_service_instance_test.go
@@ -100,6 +100,27 @@ func TestAccOPAASDatabaseServiceInstance_DefaultAccessRule(t *testing.T) {
 	})
 }
 
+func TestAccOraclePAASDatabaseServiceInstance_DesiredState(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDatabaseServiceInstanceDesiredState(ri)
+	resourceName := "oraclepaas_database_service_instance.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseServiceInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttr(
+						resourceName, "status", "Stopped"),
+				),
+			},
+		},
+	})
+}
+
 // An OCI account is need to test this
 /*
 func TestAccOPAASDatabaseServiceInstance_HDG(t *testing.T) {
@@ -263,6 +284,28 @@ func testAccDatabaseServiceInstanceDefaultAccessRule(rInt int) string {
 	default_access_rules {
 		enable_ssh = false
 	}
+  }`, rInt)
+}
+
+func testAccDatabaseServiceInstanceDesiredState(rInt int) string {
+	return fmt.Sprintf(`resource "oraclepaas_database_service_instance" "test" {
+    name        = "test-service-instance-%d"
+    description = "test service instance"
+    edition = "EE"
+    level = "PAAS"
+    shape = "oc3"
+    subscription_type = "HOURLY"
+    version = "12.2.0.1"
+    ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+
+	database_configuration {
+		admin_password = "Test_String7"
+		backup_destination = "NONE"
+		sid = "ORCL"
+		usable_storage = 15
+	}
+
+	desired_state = "stop"
   }`, rInt)
 }
 

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/access_rules.go
@@ -5,7 +5,6 @@
 // but the Operation body parameter changes from `update` to `delete`.
 // All other parameters for the resource, aside from Status should be ForceNew.
 // The READ function for the AccessRule resource is tricky, as there is
-// no exposed `GET` function on the AccessRule API.
 // There is an API endpoint to view "all" rules, however, which will be used as a
 // data source to match on a supplied AccessRule name.
 // Timeout only supported for the CREATE method

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/database_resource_client.go
@@ -26,8 +26,8 @@ func (c *ResourceClient) createResource(requestBody interface{}, responseBody in
 	return nil
 }
 
-func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}) error {
-	_, err := c.executeRequest("PUT", c.getObjectPath(c.ResourceRootPath, name), requestBody)
+func (c *ResourceClient) updateResource(name string, requestBody interface{}, responseBody interface{}, method string) error {
+	_, err := c.executeRequest(method, c.getObjectPath(c.ResourceRootPath, name), requestBody)
 	if err != nil {
 		return err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,42 +256,42 @@
 		{
 			"checksumSHA1": "V2I+dnQYydk9xDUzOqG57xQ3p7g=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "d575c4caca547dc0aa78b372317e3947d2997246",
+			"revisionTime": "2018-04-24T16:24:36Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
 		},
 		{
-			"checksumSHA1": "ew84cCBLjo4a2ukgn9QAmokvPtI=",
+			"checksumSHA1": "9Ktp0WHfH7pXeYV7z0oB4qjN5Rs=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "d575c4caca547dc0aa78b372317e3947d2997246",
+			"revisionTime": "2018-04-24T16:24:36Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
 		},
 		{
 			"checksumSHA1": "gVf0q0ZcdNA/1UiXXPY6ThgVAyE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "d575c4caca547dc0aa78b372317e3947d2997246",
+			"revisionTime": "2018-04-24T16:24:36Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
 		},
 		{
 			"checksumSHA1": "+hIqBzIjhSiGLfgBD2g3gBTDN9M=",
 			"path": "github.com/hashicorp/go-oracle-terraform/java",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "d575c4caca547dc0aa78b372317e3947d2997246",
+			"revisionTime": "2018-04-24T16:24:36Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
 		},
 		{
 			"checksumSHA1": "NuObCk0/ybL3w++EnltgrB1GQRc=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "f722055ff59a21443a8db1bafa6fd56155673cf3",
-			"revisionTime": "2018-03-23T13:39:07Z",
-			"version": "v0.8.10",
-			"versionExact": "v0.8.10"
+			"revision": "d575c4caca547dc0aa78b372317e3947d2997246",
+			"revisionTime": "2018-04-24T16:24:36Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",
@@ -683,5 +683,5 @@
 			"revisionTime": "2017-08-04T00:04:37Z"
 		}
 	],
-	"rootPath": "github.com/hashicorp/terraform-provider-oraclepaas"
+	"rootPath": "github.com/terraform-providers/terraform-provider-oraclepaas"
 }

--- a/website/docs/r/oraclepaas_database_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_database_service_instance.html.markdown
@@ -61,6 +61,9 @@ The following arguments are supported:
 * `default_access_rules` - (Optional) Specifies the details on which default access rules are enable or disabled. Default Access Rules
 are configured below.
 
+* `desired_state` - (Optional) Specifies the desired state of the servie instance. Allowed values are `start`, `stop`,
+and `restart`.
+
 * `instantiate_from_backup` - (Optional) Specify if the service instance's database should, after the instance is created, be replaced by a database
 stored in an existing cloud backup that was created using Oracle Database Backup Cloud Service. Instantiate from Backup is documented below.
 
@@ -208,5 +211,7 @@ In addition to the above, the following values are exported:
 * `glassfish_url` - The URL to use to connect to the Oracle GlassFish Server Administration Console on the service instance.
 
 * `identity_domain` - The identity domain housing the service instance.
+
+* `status` - The status of the service instance.
 
 * `uri` - The Uniform Resource Identifier for the Service Instance


### PR DESCRIPTION
This PR allows users to set the desired state of a database service instance 

```
make testacc TEST=./oraclepaas TESTARGS="-run=TestAccOraclePAASDatabaseServiceInstance_DesiredState"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./oraclepaas -v -run=TestAccOraclePAASDatabaseServiceInstance_DesiredState -timeout 180m
=== RUN   TestAccOraclePAASDatabaseServiceInstance_DesiredState
--- PASS: TestAccOraclePAASDatabaseServiceInstance_DesiredState (2744.87s)
PASS
ok  	github.com/terraform-providers/terraform-provider-oraclepaas/oraclepaas2
```