### PR TITLE
explicitly set provisionOTD when OTD block defined

### DIFF
--- a/oraclepaas/resource_java_service_instance.go
+++ b/oraclepaas/resource_java_service_instance.go
@@ -866,6 +866,7 @@ func expandOTDConfig(d *schema.ResourceData, input *java.CreateServiceInstanceIn
 		otdInfo.LoadBalancingPolicy = java.ServiceInstanceLoadBalancingPolicy(v.(string))
 	}
 
+	input.ProvisionOTD = true
 	input.Components.OTD = otdInfo
 }
 


### PR DESCRIPTION
OTD provisioning is implied by the API when when using the `managed_servers` configuration, but not when explicitly defining `cluster`s. This update explicitly sets the `provisionOTD` in the API when the oracle_traffic_director block is defined

