### PR TITLE
oraclepaas_mysql_service_instance  bug fixes

### DIFF
--- a/oraclepaas/resource_mysql_service_instance.go
+++ b/oraclepaas/resource_mysql_service_instance.go
@@ -411,16 +411,16 @@ func expandEM(input map[string]interface{}, parameter *mysql.MySQLParameters) er
 			parameter.EnterpriseMonitorAgentPassword = attrs["em_agent_password"].(string)
 		}
 
-		if val, ok := attrs["em_agent_user"].(string); ok && val != "" {
-			parameter.EnterpriseMonitorAgentUser = attrs["em_agent_user"].(string)
+		if val, ok := attrs["em_agent_username"].(string); ok && val != "" {
+			parameter.EnterpriseMonitorAgentUser = attrs["em_agent_username"].(string)
 		}
 
 		if val, ok := attrs["em_password"].(string); ok && val != "" {
 			parameter.EnterpriseMonitorManagerPassword = attrs["em_password"].(string)
 		}
 
-		if val, ok := attrs["em_user"].(string); ok && val != "" {
-			parameter.EnterpriseMonitorManagerUser = attrs["em_user"].(string)
+		if val, ok := attrs["em_username"].(string); ok && val != "" {
+			parameter.EnterpriseMonitorManagerUser = attrs["em_username"].(string)
 		}
 
 		if val, ok := attrs["em_port"].(string); ok && val != "" {

--- a/oraclepaas/resource_mysql_service_instance.go
+++ b/oraclepaas/resource_mysql_service_instance.go
@@ -167,6 +167,7 @@ func resourceOraclePAASMySQLServiceInstance() *schema.Resource {
 							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(25, 1024),
+							Default:      25,
 						},
 						"mysql_charset": {
 							Type:     schema.TypeString,

--- a/vendor/github.com/hashicorp/go-oracle-terraform/mysql/mysql_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/mysql/mysql_client.go
@@ -2,9 +2,10 @@ package mysql
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/hashicorp/go-oracle-terraform/client"
 	"github.com/hashicorp/go-oracle-terraform/opc"
-	"net/http"
 )
 
 const AUTH_HEADER = "Authorization"
@@ -54,6 +55,9 @@ func (c *MySQLClient) executeRequestWithContentType(method, path string, body in
 	}
 
 	debugReqString := fmt.Sprintf("HTTP %s Path (%s)", method, path)
+	if body != nil {
+		debugReqString = fmt.Sprintf("%s:\nBody: %+v", debugReqString, string(reqBody))
+	}
 
 	// Log the request before the authentication header, so as not to leak credentials
 	c.client.DebugLogString(fmt.Sprintf("[DEBUG] : RequestString (%+v)", debugReqString))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -256,50 +256,50 @@
 		{
 			"checksumSHA1": "rGpYaKBp3AarSHsf9r+GJNayT3w=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
 			"checksumSHA1": "GFTKpxcVxYLz+qB5/LO85pBPTks=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
 			"checksumSHA1": "HVhKKQ6jpg3W9/MspUD09Xka238=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
 			"checksumSHA1": "WUGo97xzOBoEuFenJc9sKfR6Ev4=",
 			"path": "github.com/hashicorp/go-oracle-terraform/java",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
-			"checksumSHA1": "oofKMv1sYVb19vYNDPdSIXusZts=",
+			"checksumSHA1": "KGRUB7DYJpzB+oC8rf2X6iKwdyA=",
 			"path": "github.com/hashicorp/go-oracle-terraform/mysql",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
 			"checksumSHA1": "aeXObRk6gAfuvnT+puKaEib7dm0=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "21fe72b9658066572542addae83a26c280d9f83f",
-			"revisionTime": "2018-06-20T03:03:55Z",
-			"version": "v0.9.7",
-			"versionExact": "v0.9.7"
+			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
+			"revisionTime": "2018-06-21T20:01:01Z",
+			"version": "v0.9.8",
+			"versionExact": "v0.9.8"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/website/docs/r/oraclepaas_mysql_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_mysql_service_instance.html.markdown
@@ -8,7 +8,7 @@ description: |-
 ---
 
 # oraclepaas_mysql_service_instance
-The `oraclepaas_mysql_service_instance` resource creates and manages a an Oracle MySQL Cloud Service instance on the Oracle Cloud Platform.
+The `oraclepaas_mysql_service_instance` resource creates and manages an Oracle MySQL Cloud Service instance on the Oracle Cloud Platform.
 
 ## Example Usage
 
@@ -18,8 +18,7 @@ resource "oraclepaas_mysql_service_instance" "default" {
   description               = "This is a simple mysql instance"
   vm_public_key             = "A SSH public key"
   backup_destination        = "NONE"
-  enable_notification       = true
-  notification_email        = myemail@mydomain.com
+  notification_email        = "myemail@mydomain.com"
   shape                     = "oc3"
   ssh_public_key            = "ssh-public-key"
 
@@ -36,8 +35,6 @@ resource "oraclepaas_mysql_service_instance" "default" {
     mysql_port              = 3306
     mysql_username          = "root"
     mysql_password          = "MySqlPassword_1"
-    mysql_charset           = "utf8"
-    mysql_collation         = "utf8_general_ci"
 
     enterprise_monitor_configuration {
       em_agent_username     = "MyEmAgentUser"
@@ -60,7 +57,7 @@ The following arguments are supported:
 
 * `ssh_public_key` - (Required). The public key for the secure shell (SSH). This key wil be used for authentication when the user logs on to the instance over SSH.
 
-* `backup_destination` - (Required) The destination where the database backups will be stored. 
+* `backup_destination` - (Required) The destination where the database backups will be stored.
 
 * `shape` - (Required) The desired compute shape.  A shape defines the number of Oracle Compute Units (OCPUs) and amount of memory (RAM). See [About Shapes](http://www.oracle.com/pls/topic/lookup?ctx=cloud&id=OCSUG210) in _Using Oracle Compute Cloud Service_ for more information about shapes.
 
@@ -73,7 +70,6 @@ The following arguments are supported:
 * `notification_email` - (Optional) The email address to send notifications around successful or unsuccessful completions of the instance-creation operation.
 
 * `ip_network` - (Optional) This attribute is only applicable to accounts where regions are supported. The three-part name of an IP network to which the service instance is added. For example: /Compute-identity_domain/user/object
-
 
 * `subnet` -(Optional) This attribute is relevant to only Oracle Cloud Infrastructure. Specify the Oracle Cloud Identifier (OCID) of a subnet from a virtual cloud network (VCN) that you had created previously in Oracle Cloud Infrastructure. For the instructions to create a VCN and subnet, see [Prerequisites for Oracle Platform Services on Oracle Cloud Infrastructure](http://www.oracle.com/pls/topic/lookup?ctx=en/cloud/paas/java-cloud&id=oci_general_paasprereqs) in the Oracle Cloud Infrastructure documentation.
 
@@ -108,7 +104,7 @@ The following arguments are supported:
 
 * `mysql_username` - (Optional) The Administration user for connecting to the service via th MySQL protocol. Default value is `root`.
 
-* `mysql_password` - (Optional) The password for the MySQL Administration user. 
+* `mysql_password` - (Optional) The password for the MySQL Administration user.
 
 * `source_service_name` - (Optional) When present, indicates that the service instance should be created as a "snapshot clone" of another service instance. Provide the name of the existing service instance whose snapshot is to be used. `db_name`, `mysql_charset`, `mysql_collation`, `enterpriseMonitor`, and associated MySQL server component parameters do not apply when cloning a service from a snapshot. For those parameters, the clone operation uses the values defined in the snapshot of the source service instance.
 
@@ -118,12 +114,12 @@ The following arguments are supported:
 
 `enterprise_monitor_configuration` supports the following :
 
-* `em_agent_username` - (Optional). Name for the Enterprise Monitor agent user. 
+* `em_agent_username` - (Optional). Name for the Enterprise Monitor agent user.
 
 * `em_agent_password` - (Optional). Password for MySQL Enterprise Monitor agent.
 
-* `em_username` - (Optional) Name for the Enterprise Monitor Manager user. 
+* `em_username` - (Optional) Name for the Enterprise Monitor Manager user.
 
-* `em_password` - (Optional) Password for MySQL Enterprise Monitor manager. 
+* `em_password` - (Optional) Password for MySQL Enterprise Monitor manager.
 
 * `em_port` - (Optional) The port number for the MySQL Enterprise Monitor instance. The default is 18443.


### PR DESCRIPTION
- Resolves issue with Enterprise Monitor User and Agent name not getting set. 
- Add default value for `db_storage` (was getting get to 0 if value was not provided)
- Doc fixes, remove char set in example to encourage us of default charset setting.
