### PR TITLE
ensure ProvisionOTD is disabled unless the OTD config is provided.

### DIFF
--- a/oraclepaas/resource_java_service_instance.go
+++ b/oraclepaas/resource_java_service_instance.go
@@ -669,6 +669,7 @@ func resourceOraclePAASJavaServiceInstanceCreate(d *schema.ResourceData, meta in
 		BackupDestination:  java.ServiceInstanceBackupDestination(d.Get("backup_destination").(string)),
 		EnableAdminConsole: d.Get("enable_admin_console").(bool),
 		UseIdentityService: d.Get("use_identity_service").(bool),
+		ProvisionOTD:       false, // force default to false, but may be overridden below in expandOTDConfig
 	}
 
 	if val, ok := d.GetOk("service_version"); ok {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/java/java_resource_client.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/java/java_resource_client.go
@@ -36,9 +36,12 @@ func (c *ResourceClient) getResource(name string, responseBody interface{}) erro
 	return c.unmarshalResponseBody(resp, responseBody)
 }
 
-func (c *ResourceClient) updateResource(name, path, method string, requestBody interface{}) error {
-	_, err := c.executeRequest(method, fmt.Sprintf("%s%s", c.getObjectPath(c.ResourceRootPath, name), path), requestBody)
-	return err
+func (c *ResourceClient) updateResource(name, path, method string, requestBody interface{}, responseBody interface{}) error {
+	resp, err := c.executeRequest(method, fmt.Sprintf("%s%s", c.getObjectPath(c.ResourceRootPath, name), path), requestBody)
+	if err != nil {
+		return err
+	}
+	return c.unmarshalResponseBody(resp, responseBody)
 }
 
 // ServiceInstance needs a PUT and a body to be destroyed

--- a/vendor/github.com/hashicorp/go-oracle-terraform/java/jobs.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/java/jobs.go
@@ -1,0 +1,104 @@
+package java
+
+import (
+	"fmt"
+	"time"
+)
+
+// API URI Paths for the Root Job path
+const (
+	JobRootPath = "/paas/api/v1.1/activitylog/%s/job/%s"
+)
+
+// Default Poll Interval value
+const waitForJobPollInterval = 1 * time.Second
+
+// JobClient is a client for the Service functions of the Job API.
+type JobClient struct {
+	ResourceClient
+	PollInterval time.Duration
+	Timeout      time.Duration
+}
+
+// Jobs returns a JobClient for checking job status
+func (c *Client) Jobs() *JobClient {
+	return &JobClient{
+		ResourceClient: ResourceClient{
+			Client:           c,
+			ResourceRootPath: JobRootPath,
+		},
+	}
+}
+
+// JobStatus defines the constants for the status of a job
+type JobStatus string
+
+const (
+	// JobStatusRunning - the job is still running.
+	JobStatusRunning JobStatus = "RUNNING"
+	// JobStatusFailed - the job has failed.
+	JobStatusFailed JobStatus = "FAILED"
+	// JobStatusSucceed - the job has succeeded.
+	JobStatusSucceed JobStatus = "SUCCEED"
+)
+
+// JobResponse details the job information received after submitting a request
+type JobResponse struct {
+	Details Details `json:"details"`
+}
+
+// Details details the attributes of the specific job that is running on the service instance
+type Details struct {
+	JobID   string `json:"jobId"`
+	Message string `json:"message"`
+}
+
+// Job details the attributes related to a job
+type Job struct {
+	// Job ID
+	ID int `json:"jobId"`
+	// Status of the job
+	Status JobStatus `json:"status"`
+}
+
+// GetJobInput specifies which job to retrieve
+type GetJobInput struct {
+	// ID of the job.
+	// Required.
+	ID string
+}
+
+// GetJob retrieves the job with the given id
+func (c *JobClient) GetJob(getInput *GetJobInput) (*Job, error) {
+	var job Job
+	if err := c.getResource(getInput.ID, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
+}
+
+// WaitForJobCompletion waits for a service instance to be in the desired state
+func (c *JobClient) WaitForJobCompletion(input *GetJobInput, pollInterval, timeoutSeconds time.Duration) error {
+	return c.client.WaitFor("job to succeed", pollInterval, timeoutSeconds, func() (bool, error) {
+		info, getErr := c.GetJob(input)
+		if getErr != nil {
+			return false, getErr
+		}
+		c.client.DebugLogString(fmt.Sprintf("job ID is %v", info.ID))
+		switch s := info.Status; s {
+		case JobStatusSucceed: // Target State
+			c.client.DebugLogString("Job Succeeded")
+			return true, nil
+		case JobStatusFailed:
+			c.client.DebugLogString("Job Failed")
+			return false, fmt.Errorf("Job %q failed", input.ID)
+		case JobStatusRunning:
+			c.client.DebugLogString("Job Running")
+			return false, nil
+		default:
+			c.client.DebugLogString(fmt.Sprintf("Unknown job state: %s, waiting", s))
+			return false, nil
+		}
+	})
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -278,12 +278,12 @@
 			"versionExact": "v0.9.8"
 		},
 		{
-			"checksumSHA1": "WUGo97xzOBoEuFenJc9sKfR6Ev4=",
+			"checksumSHA1": "qRqIqDU8jPU50EVgs0BKYXsANec=",
 			"path": "github.com/hashicorp/go-oracle-terraform/java",
-			"revision": "9f6de3c5bc56e63f48f7c7ddd96000fd48c86023",
-			"revisionTime": "2018-06-21T20:01:01Z",
-			"version": "v0.9.8",
-			"versionExact": "v0.9.8"
+			"revision": "267cd1957aac3990025de350264b26d7d6c736dc",
+			"revisionTime": "2018-07-17T19:37:11Z",
+			"version": "v0.12.0",
+			"versionExact": "v0.12.0"
 		},
 		{
 			"checksumSHA1": "KGRUB7DYJpzB+oC8rf2X6iKwdyA=",

--- a/website/docs/r/oraclepaas_java_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_java_service_instance.html.markdown
@@ -119,7 +119,7 @@ value is false.
 * `weblogic_server` - (Required) The attributes required to create a WebLogic server alongside the java service instance.
 WebLogic Server is documented below.
 
-* `otd` - (Optional) The attributes required to create an Oracle Traffic Director (Load balancer). OTD is
+* `oracle_traffic_director` - (Optional) The attributes required to create an Oracle Traffic Director (Load balancer). OTD is
 documented below.
 
 * `level` - (Optional) Service level for the service instance. Possible values are `BASIC` or `PAAS`. Default


### PR DESCRIPTION
Force ProvisionOTD to be set to false unless OTD config is provided. Dependent on https://github.com/hashicorp/go-oracle-terraform/pull/160 which ensures the `provisionOTD` is always set in the create request.

- [x] govendor updated SDK

