### PR TITLE
WIP: Fix DBCS/JCS IP Reservations setting

### DIFF
--- a/oraclepaas/resource_database_service_instance.go
+++ b/oraclepaas/resource_database_service_instance.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	opcClient "github.com/hashicorp/go-oracle-terraform/client"
@@ -522,7 +523,6 @@ func resourceOPAASDatabaseServiceInstanceCreate(d *schema.ResourceData, meta int
 	input := database.CreateServiceInstanceInput{
 		Name:                      d.Get("name").(string),
 		Edition:                   database.ServiceInstanceEdition(d.Get("edition").(string)),
-		IPReservations:            getStringList(d, "ip_reservations"),
 		IsBYOL:                    d.Get("bring_your_own_license").(bool),
 		Level:                     database.ServiceInstanceLevel(d.Get("level").(string)),
 		Shape:                     database.ServiceInstanceShape(d.Get("shape").(string)),
@@ -545,7 +545,7 @@ func resourceOPAASDatabaseServiceInstanceCreate(d *schema.ResourceData, meta int
 	}
 
 	if _, ok := d.GetOk("ip_reservations"); ok {
-		input.IPReservations = getStringList(d, "ip_reservations")
+		input.IPReservations = strings.Join(getStringList(d, "ip_reservations"), ",")
 	}
 
 	if v, ok := d.GetOk("region"); ok {

--- a/oraclepaas/resource_java_service_instance.go
+++ b/oraclepaas/resource_java_service_instance.go
@@ -903,7 +903,7 @@ func expandWebLogicConfig(d *schema.ResourceData, input *java.CreateServiceInsta
 		webLogicServer.ClusterName = v.(string)
 	}
 	if v := attrs["ip_reservations"]; v != nil {
-		webLogicServer.IPReservations = getStringList(d, "weblogic_server.0.ip_reservations")
+		webLogicServer.IPReservations = strings.Join(getStringList(d, "weblogic_server.0.ip_reservations"), ",")
 	}
 	if v := attrs["middleware_volume_size"]; v != nil {
 		webLogicServer.MWVolumeSize = v.(string)
@@ -932,7 +932,7 @@ func expandOTDConfig(d *schema.ResourceData, input *java.CreateServiceInstanceIn
 		otdInfo.HAEnabled = v.(bool)
 	}
 	if v := attrs["ip_reservations"]; v != nil {
-		otdInfo.IPReservations = getStringList(d, "oracle_traffic_director.0.ip_reservations")
+		otdInfo.IPReservations = strings.Join(getStringList(d, "oracle_traffic_director.0.ip_reservations"), ",")
 	}
 	if v := attrs["load_balancing_policy"]; v != nil {
 		otdInfo.LoadBalancingPolicy = java.ServiceInstanceLoadBalancingPolicy(v.(string))

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
@@ -348,7 +348,7 @@ type CreateServiceInstanceInput struct {
 	// A single IP reservation name or multiple IP reservation names separated by commas. Only IP reservations created in the specified region can be used.
 	// When IP reservations are used, all compute nodes of an instance must be provisioned with IP reservations, so the number of names in ipReservations must match the number of compute nodes in the service instance.
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Service level for the service instance
 	// Required.
 	Level ServiceInstanceLevel `json:"level"`

--- a/vendor/github.com/hashicorp/go-oracle-terraform/java/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/java/service_instance.go
@@ -1025,7 +1025,7 @@ type CreateOTD struct {
 	// IP reservations. See the My Oracle Support document titled How to Request Authorized IPs for Provisioning
 	// a Java Cloud Service with Database Exadata Cloud Service (MOS Note 2163568.1).
 	// Optional.
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// Policy to use for routing requests to the load balancer. Valid policies include:
 	// Optional.
 	LoadBalancingPolicy ServiceInstanceLoadBalancingPolicy `json:"loadBalancingPolicy,omitempty"`
@@ -1201,7 +1201,7 @@ type CreateWLS struct {
 	// Support document titled How to Request Authorized IPs for Provisioning a Java Cloud Service with Database Exadata
 	// Cloud Service (MOS Note 2163568.1).
 	// Optional
-	IPReservations []string `json:"ipReservations,omitempty"`
+	IPReservations string `json:"ipReservations,omitempty"`
 	// One or more Managed Server JVM arguments separated by a space.
 	// You cannot specify any arguments that are related to JVM heap sizes and PermGen spaces (for example, -Xms, -Xmx,
 	// -XX:PermSize, and -XX:MaxPermSize).


### PR DESCRIPTION
Fixes #45

Update to pass the IP Reservation names as a single string of comma separated values instead of list of strings.

Dependent on https://github.com/hashicorp/go-oracle-terraform/pull/165

- [ ] TODO update vendored SDK