### PR TITLE
Database compute node data source

### DIFF
--- a/oraclepaas/data_source_database_compute_nodes.go
+++ b/oraclepaas/data_source_database_compute_nodes.go
@@ -2,7 +2,6 @@ package oraclepaas
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/go-oracle-terraform/database"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -22,10 +21,6 @@ func dataSourceOraclePAASDatabaseComputeNodes() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"availability_domain": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"connect_descriptor": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -70,10 +65,6 @@ func dataSourceOraclePAASDatabaseComputeNodes() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"subnet": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 					},
 				},
 			},
@@ -110,8 +101,6 @@ func dataSourceOraclePAASDatabaseComputeNodesRead(d *schema.ResourceData, meta i
 	d.Set("name", name)
 
 	computeNodes, err := flattenComputeNodes(d, result.Nodes)
-	// TODO not working!
-	log.Printf(">>> computeNodes: %+v", computeNodes) // TODO remove
 	if err != nil {
 		return err
 	}
@@ -127,7 +116,6 @@ func flattenComputeNodes(d *schema.ResourceData, result []database.ComputeNodeIn
 
 	for _, info := range result {
 		node := make(map[string]interface{})
-		node["availability_domain"] = info.AvailabilityDomain
 		node["connect_descriptor"] = info.ConnectDescriptor
 		node["connect_descriptor_with_public_ip"] = info.ConnectDescriptorWithPublicIP
 		node["hostname"] = info.Hostname
@@ -135,12 +123,11 @@ func flattenComputeNodes(d *schema.ResourceData, result []database.ComputeNodeIn
 		node["listener_port"] = info.ListenerPort
 		node["pdb_name"] = info.PDBName
 		node["reserved_ip"] = info.ReservedIP
+		node["shape"] = info.Shape
 		node["sid"] = info.SID
 		node["status"] = info.Status
 		node["storage_allocated"] = info.StorageAllocated
-		node["subnet"] = info.Subnet
 		flattenedComputeNodes = append(flattenedComputeNodes, node)
-		log.Printf(">>> flattenedComputeNodes: %+v", flattenedComputeNodes) // TODO remove
 	}
 
 	return flattenedComputeNodes, nil

--- a/oraclepaas/data_source_database_compute_nodes.go
+++ b/oraclepaas/data_source_database_compute_nodes.go
@@ -1,0 +1,147 @@
+package oraclepaas
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-oracle-terraform/database"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceOraclePAASDatabaseComputeNodes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOraclePAASDatabaseComputeNodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"compute_nodes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"availability_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connect_descriptor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"connect_descriptor_with_public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"initial_primary": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"listener_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pdb_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reserved_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shape": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_allocated": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"subnet": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOraclePAASDatabaseComputeNodesRead(d *schema.ResourceData, meta interface{}) error {
+	dbClient, err := getDatabaseClient(meta)
+	if err != nil {
+		return err
+	}
+	client := dbClient.ComputeNodes()
+
+	// Get required attributes
+	name := d.Get("name").(string)
+
+	input := database.GetComputeNodesInput{
+		ServiceInstanceID: name,
+	}
+
+	result, err := client.GetComputeNodes(&input)
+	if err != nil {
+		return err
+	}
+
+	// Not found, don't error
+	if result == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.SetId(name)
+	d.Set("name", name)
+
+	computeNodes, err := flattenComputeNodes(d, result.Nodes)
+	// TODO not working!
+	log.Printf(">>> computeNodes: %+v", computeNodes) // TODO remove
+	if err != nil {
+		return err
+	}
+	if err := d.Set("compute_nodes", computeNodes); err != nil {
+		return fmt.Errorf("Error setting Compute Node info: %+v", err)
+	}
+
+	return nil
+}
+
+func flattenComputeNodes(d *schema.ResourceData, result []database.ComputeNodeInfo) ([]interface{}, error) {
+	flattenedComputeNodes := make([]interface{}, 0)
+
+	for _, info := range result {
+		node := make(map[string]interface{})
+		node["availability_domain"] = info.AvailabilityDomain
+		node["connect_descriptor"] = info.ConnectDescriptor
+		node["connect_descriptor_with_public_ip"] = info.ConnectDescriptorWithPublicIP
+		node["hostname"] = info.Hostname
+		node["initial_primary"] = info.InitialPrimary
+		node["listener_port"] = info.ListenerPort
+		node["pdb_name"] = info.PDBName
+		node["reserved_ip"] = info.ReservedIP
+		node["sid"] = info.SID
+		node["status"] = info.Status
+		node["storage_allocated"] = info.StorageAllocated
+		node["subnet"] = info.Subnet
+		flattenedComputeNodes = append(flattenedComputeNodes, node)
+		log.Printf(">>> flattenedComputeNodes: %+v", flattenedComputeNodes) // TODO remove
+	}
+
+	return flattenedComputeNodes, nil
+}

--- a/oraclepaas/data_source_database_compute_nodes_test.go
+++ b/oraclepaas/data_source_database_compute_nodes_test.go
@@ -1,0 +1,75 @@
+package oraclepaas
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-oracle-terraform/database"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccOPAASDataSourceDatabaseComputeNodes_Basic(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccDataSourceDatabaseComputeNodesBasic(ri)
+	resourceName := "data.oraclepaas_database_compute_nodes.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatabaseServiceInstanceExists,
+					resource.TestCheckResourceAttrSet(resourceName, "compute_nodes"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabaseComputeNodesExists(s *terraform.State) error {
+	client := testAccProvider.Meta().(*OPAASClient).databaseClient.ComputeNodes()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oraclepaas_database_compute_nodes" {
+			continue
+		}
+
+		input := database.GetComputeNodesInput{
+			ServiceInstanceID: rs.Primary.Attributes["name"],
+		}
+		if _, err := client.GetComputeNodes(&input); err != nil {
+			return fmt.Errorf("Error retrieving state of Database Compute Nodes %s: %+v", input.ServiceInstanceID, err)
+		}
+	}
+
+	return nil
+}
+
+func testAccDataSourceDatabaseComputeNodesBasic(rInt int) string {
+	return fmt.Sprintf(`
+resource "oraclepaas_database_service_instance" "test" {
+    name        = "test-service-instance-%d"
+    description = "test service instance"
+    edition = "EE"
+    level = "PAAS"
+    shape = "oc3"
+    subscription_type = "HOURLY"
+    version = "12.2.0.1"
+    ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3QxPp0BFK+ligB9m1FBcFELyvN5EdNUoSwTCe4Zv2b51OIO6wGM/dvTr/yj2ltNA/Vzl9tqf9AUBL8tKjAOk8uukip6G7rfigby+MvoJ9A8N0AC2te3TI+XCfB5Ty2M2OmKJjPOPCd6+OdzhT4cWnPOM+OAiX0DP7WCkO4Kx2kntf8YeTEurTCspOrRjGdo+zZkJxEydMt31asu9zYOTLmZPwLCkhel8vY6SnZhDTNSNkRzxZFv+Mh2VGmqu4SSxfVXr4tcFM6/MbAXlkA8jo+vHpy5sC79T4uNaPu2D8Ed7uC3yDdO3KRVdzZCfWHj4NjixdMs2CtK6EmyeVOPuiYb8/mcTybrb4F/CqA4jydAU6Ok0j0bIqftLyxNgfS31hR1Y3/GNPzly4+uUIgZqmsuVFh5h0L7qc1jMv7wRHphogo5snIp45t9jWNj8uDGzQgWvgbFP5wR7Nt6eS0kaCeGQbxWBDYfjQE801IrwhgMfmdmGw7FFveCH0tFcPm6td/8kMSyg/OewczZN3T62ETQYVsExOxEQl2t4SZ/yqklg+D9oGM+ILTmBRzIQ2m/xMmsbowiTXymjgVmvrWuc638X6dU2fKJ7As4hxs3rA1BA5sOt0XyqfHQhtYrL/Ovb1iV+C7MRhKicTyoNTc7oVcDDG0VW785d8CPqttDi50w=="
+    bring_your_own_license = true
+
+    database_configuration {
+        admin_password = "Test_String7"
+        backup_destination = "NONE"
+        sid = "ORCL"
+        usable_storage = 15
+    }
+}
+
+data "oraclepaas_database_compute_nodes" "test" {
+    name = "${oraclepaas_database_service_instance.test.name}"
+}`, rInt)
+}

--- a/oraclepaas/provider.go
+++ b/oraclepaas/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"oraclepaas_database_service_instance": dataSourceOraclePAASDatabaseServiceInstance(),
+			"oraclepaas_database_compute_nodes":    dataSourceOraclePAASDatabaseComputeNodes(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/compute_nodes.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/compute_nodes.go
@@ -1,0 +1,93 @@
+package database
+
+// API URI Paths for Container and Root objects
+const (
+	DBComputeNodeContainerPath = "paas/service/dbcs/api/v1.1/instances/%s/%s/servers"
+	DBComputeNodeRootPath      = "paas/service/dbcs/api/v1.1/instances/%s/%s/servers/%s"
+)
+
+// ComputeNodes returns a UtilityClient for managing Server Nodes for a DBaaS Service Instance
+func (c *Client) ComputeNodes() *UtilityClient {
+	return &UtilityClient{
+		UtilityResourceClient: UtilityResourceClient{
+			Client:           c,
+			ContainerPath:    DBComputeNodeContainerPath,
+			ResourceRootPath: DBComputeNodeRootPath,
+		},
+	}
+}
+
+// ComputeNodeInfo returns the details of a single Compute Node
+type ComputeNodeInfo struct {
+	// Name of the availability domain within the region where the compute node is provisioned.
+	// OCI only.
+	AvailabilityDomain string `json:"availabilityDomain"`
+	// The connection descriptor for Oracle Net Services (SQL*Net).
+	ConnectDescriptor string `json:"connect_descriptor"`
+	// The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
+	ConnectDescriptorWithPublicIP string `json:"connect_descriptor_with_public_ip"`
+	// The user name of the Oracle Cloud user who created the service instance.
+	CreatedBy string `json:"created_by"`
+	// The job id of the job that created the service instance.
+	CreationJobID string `json:"creation_job_id"`
+	// The date-and-time stamp when the service instance was created.
+	CreationTime string `json:"creation_time"`
+	// The host name of the compute node.
+	Hostname string `json:"hostname"`
+	// Indicates whether the compute node hosted the primary database of an Oracle Data Guard
+	// configuration when the service instance was created.
+	InitialPrimary bool `json:"initialPrimary"`
+	// The listener port for Oracle Net Services (SQL*Net) connections.
+	ListenerPort int `json:"listenerPort"`
+	// The size in GB of the memory allocated to the compure node.
+	// Exadata only.
+	MemoryAllocated int `json:"memoryAllocated"`
+	// Number of CPU Cores.
+	// Exadata only.
+	NumberOfCores int `json:"numberOfCores"`
+	// The name of the default PDB (pluggable database) created when the service instance was created.
+	PDBName string `json:"pdbName"`
+	// The IP address of the compute node.
+	ReservedIP string `json:"reservedIP"`
+	// The Oracle Compute Cloud shape of the compute node.
+	Shape string `json:"shape"`
+	// The SID of the database on the compute node.
+	SID string `json:"sid"`
+	// The status of the compute node.
+	Status string `json:"string"`
+	// The size in GB of the storage allocated to the compute node.
+	// For compute nodes of a service instance hosting an Oracle RAC database, this number does not
+	// include the storage shared by the nodes
+	StorageAllocated int `json:"storageAllocated"`
+	// Name of the subnet within the region where the compute node is provisioned.
+	Subnet string `json:"subnet"`
+	// Virtual Machine type
+	VMType string `json:"vmType"`
+}
+
+// ComputeNodesInfo - contains details of a Compute Nodes for a service instance
+type ComputeNodesInfo struct {
+	// List of Compute Nodes
+	Nodes []ComputeNodeInfo `json:"-"`
+}
+
+// GetComputeNodesInput Get Request input to query compute nodes for a service instance
+type GetComputeNodesInput struct {
+	// Name of the DBaaS service instance.
+	// Required
+	ServiceInstanceID string `json:"-"`
+}
+
+// GetComputeNodes gets details of all Compute Nodes for a Service Instance
+func (c *UtilityClient) GetComputeNodes(input *GetComputeNodesInput) (*ComputeNodesInfo, error) {
+	if input.ServiceInstanceID != "" {
+		c.ServiceInstanceID = input.ServiceInstanceID
+	}
+	var computeNodes []ComputeNodeInfo
+	if err := c.getResource("", &computeNodes); err != nil {
+		return nil, err
+	}
+	return &ComputeNodesInfo{
+		Nodes: computeNodes,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/compute_nodes.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/compute_nodes.go
@@ -54,7 +54,7 @@ type ComputeNodeInfo struct {
 	// The SID of the database on the compute node.
 	SID string `json:"sid"`
 	// The status of the compute node.
-	Status string `json:"string"`
+	Status string `json:"status"`
 	// The size in GB of the storage allocated to the compute node.
 	// For compute nodes of a service instance hosting an Oracle RAC database, this number does not
 	// include the storage shared by the nodes

--- a/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/database/service_instance.go
@@ -58,7 +58,9 @@ type ServiceInstanceLevel string
 const (
 	// ServiceInstanceLevelPAAS - PAAS: The Oracle Database Cloud Service service level
 	ServiceInstanceLevelPAAS ServiceInstanceLevel = "PAAS"
-	// ServiceInstanceLevelBasic - BASIC: The Oracle Database Cloud Service - Virtual Image service level
+	// PAAS_EXADATA: The Oracle Exadata Cloud Service service level
+	ServiceInstanceLevelEXADATA ServiceInstanceLevel = "PAAS_EXADATA"
+	// BASIC: The Oracle Database Cloud Service - Virtual Image service level
 	ServiceInstanceLevelBasic ServiceInstanceLevel = "BASIC"
 )
 
@@ -194,6 +196,15 @@ const (
 	ServiceInstanceTerminating ServiceInstanceState = "Terminating"
 )
 
+type ServiceInstanceDatabaseTemplate string
+
+const (
+	// oltp: configures the starter database for a transactional workload
+	ServiceInstanceTemplateOLPT ServiceInstanceDatabaseTemplate = "oltp"
+	// dw: configures the starter database for a decision support or data warehouse workload
+	ServiceInstanceTemplateDW ServiceInstanceDatabaseTemplate = "dw"
+)
+
 // ServiceInstanceUsage defines the constants for a service instance usage
 type ServiceInstanceUsage string
 
@@ -231,12 +242,14 @@ type ServiceInstance struct {
 	CharSet string `json:"charset"`
 	// The Oracle Storage Cloud container for backups.
 	CloudStorageContainer string `json:"cloud_storage_container"`
+	// Name of the cluster supporting the Exadata Cloud Service database deployment.
+	ClusterName string `json:"cluster_names"`
 	// The Oracle Cloud location housing the service instance.
 	ComputeSiteName string `json:"compute_site_name"`
 	// The connection descriptor for Oracle Net Services (SQL*Net).
 	ConnectDescriptor string `json:"connect_descriptor"`
 	// The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
-	ConnectorDescriptorWithPublicIP string `json:"connect_descriptor_with_public_ip"`
+	ConnectDescriptorWithPublicIP string `json:"connect_descriptor_with_public_ip"`
 	// The user name of the Oracle Cloud user who created the service instance.
 	CreatedBy string `json:"created_by"`
 	// The job id of the job that created the service instance.
@@ -277,8 +290,12 @@ type ServiceInstance struct {
 	Level ServiceInstanceLevel `json:"level"`
 	// The national character set of the database.
 	NCharSet string `json:"ncharset"`
+	// The number of Oracle Compute Service IP reservations assigned to the service instance.
+	NumIPReservations int `json:"num_ip_reservations"`
 	// The number of compute nodes in the service instance.
 	NumNodes string `json:"num_nodes"`
+	// Name for the Oracle Home directory location (Exadata Cloud Service only)
+	OracleHomeName string `json:"oracleHomeName"`
 	// The name of the default PDB (pluggable database) created when the service instance was created.
 	PDBName string `json:"pdbName"`
 	// This attribute is only applicable to accounts where regions are supported.
@@ -299,6 +316,8 @@ type ServiceInstance struct {
 	// Applicable only in Oracle Cloud Infrastructure regions.
 	// Name of the subnet within the region where the Oracle Database Cloud Service instance is provisioned.
 	Subnet string `json:"subnet"`
+	// The subscription name
+	SubscriptionName string `json:"subscription_name"`
 	// The billing frequency of the service instance; either MONTHLY or HOURLY.
 	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
 	// The time zone of the operating system.
@@ -314,12 +333,12 @@ type ServiceInstance struct {
 	// Indicates whether the service instance was provisioned with high performance storage.
 	UseHighPerformanceStorage bool `json:"useHighPerformanceStorage"`
 	// The listener port for Oracle Net Services (SQL*Net) connections.
-	ListenerPort int `json:"listener_port"`
-	// The number of Oracle Compute Service IP reservations assigned to the service instance.
-	NumIPReservations int `json:"num_ip_reservations"`
+	ListenerPort int `json:"listenerPort"`
 	// For service instances hosting an Oracle RAC database, the size in GB of the storage shared
 	// and accessed by the nodes of the RAC database.
 	TotalSharedStorage int `json:"total_shared_storage"`
+	// Exadata networking info
+	NetworkingInfo NetworkingInfo `json:"networking_info"`
 }
 
 // CreateServiceInstanceInput specifies the create request for a database service instance
@@ -327,6 +346,13 @@ type CreateServiceInstanceInput struct {
 	// Name of the availability domain within the region where the Oracle Database Cloud Service instance is to be provisioned.
 	// Optional
 	AvailabilityDomain string `json:"availabilityDomain,omitempty"`
+	// Name of the cluster supporting the Exadata Cloud Service database deployment.
+	// Optional. Exadata Cloud Service only.
+	ClusterName string `json:"clusterName,omitempty"`
+	// The template to use for the starter database. `dw` or `oltp`.
+	// Include this parameter only when creating a starter database. The starter database is the first Exadata Cloud Service database deployment that you create on your Exadata system. Subsequent databases are created with a standardized database configuration.
+	// Optional. Exadata Cloud Service only.
+	DatabaseTemplate string `json:"dbTemplate,omitempty"`
 	// Free-form text that provides additional information about the service instance.
 	// Optional.
 	Description string `json:"description,omitempty"`
@@ -337,6 +363,19 @@ type CreateServiceInstanceInput struct {
 	// Cloud Service instance as Cluster Database.
 	// Required.
 	Edition ServiceInstanceEdition `json:"edition"`
+	// Specify if you want an email notification sent upon successful or unsuccessful completion of the instance-creation operation.
+	// When true, you must also specify notificationEmail. Valid values are true and false. Default value is false.
+	// Optional
+	EnableNotification bool `json:"enableNotification,omitempty"`
+	// Required if level is `PAAS_EXADATA`
+	// Name of the Exadata system on which to create the Exadata Cloud Service database deployment.
+	// Optional. Exadata Cloud Service only.
+	ExadataSystemName string `json:"exadataSystemName,omitempty"`
+	// Specify if you want to use an existing perpetual license to Oracle Database to establish the right to use Oracle Database on the new instance.
+	// When true, your Oracle Cloud account will be charged a lesser amount for the new instance because the right to use Oracle Database is covered by your perpetual license agreement.
+	// Valid values are true and false. Default value is false.
+	// Optional
+	IsBYOL *bool `json:"isBYOL,omitempty"`
 	// This parameter is not available on Oracle Cloud at Customer.
 	// Applicable only if region is an Oracle Cloud Infrastructure Classic region.
 	// The three-part name of a custom IP network to use. For example: /Compute-identity_domain/user/object.
@@ -364,6 +403,10 @@ type CreateServiceInstanceInput struct {
 	// Must be unique within the identity domain.
 	// Required.
 	Name string `json:"serviceName"`
+	// Specifies the list of compute nodes that host database instances for the database deployment.
+	// Separate compute node names with a comma. If nodelist is not specified the database is deployed across all compute nodes
+	// Optional. Exadata Cloud Service only.
+	NodeList string `json:"nodelist,omitempty"`
 	// Required if enableNotification is set to true.
 	// The email address to send completion notifications to.
 	// This parameter is not available on Oracle Cloud at Customer.
@@ -376,7 +419,7 @@ type CreateServiceInstanceInput struct {
 	// Desired compute shape. A shape defines the number of Oracle Compute Units (OCPUs) and amount
 	// of memory (RAM).
 	// Required.
-	Shape ServiceInstanceShape `json:"shape"`
+	Shape ServiceInstanceShape `json:"shape,omitempty"`
 	// Required if region is an Oracle Cloud Infrastructure region.
 	// Name of the subnet within the region where the Oracle Database Cloud Service instance is to be provisioned.
 	// Optional
@@ -388,7 +431,12 @@ type CreateServiceInstanceInput struct {
 	SubscriptionType ServiceInstanceSubscriptionType `json:"subscriptionType"`
 	// Applicable only in Oracle Cloud Infrastructure regions.
 	// Array of one JSON object that specifies configuration details of the standby database when failoverDatabase is set to true. disasterRecovery must be set to true.
-	Standbys []StandBy `json:"standbys"`
+	Standbys []StandBy `json:"standbys,omitempty"`
+	// Specify if high performance storage should be used for the Database Cloud Service instance. Default data storage will allocate your database
+	// block storage on spinning devices. By checking this box, your block storage will be allocated on solid state devices. Valid values are true and false.
+	// Default value is false.
+	// Optional
+	UseHighPerformanceStorage bool `json:"useHighPerformanceStorage,omitempty"`
 	// Oracle Database software version
 	// Required.
 	Version ServiceInstanceVersion `json:"version"`
@@ -396,22 +444,8 @@ type CreateServiceInstanceInput struct {
 	// connecting to the Database Cloud Service instance using an SSH client. You generate an
 	// SSH public-private key pair using a standard SSH key generation tool. See Connecting to
 	// a Compute Node Through Secure Shell (SSH) in Using Oracle Database Cloud Service.
-	// Required.
-	VMPublicKey string `json:"vmPublicKeyText"`
-	// Specify if you want an email notification sent upon successful or unsuccessful completion of the instance-creation operation.
-	// When true, you must also specify notificationEmail. Valid values are true and false. Default value is false.
-	// Optional
-	EnableNotification bool `json:"enableNotification,omitempty"`
-	// Specify if you want to use an existing perpetual license to Oracle Database to establish the right to use Oracle Database on the new instance.
-	// When true, your Oracle Cloud account will be charged a lesser amount for the new instance because the right to use Oracle Database is covered by your perpetual license agreement.
-	// Valid values are true and false. Default value is false.
-	// Optional
-	IsBYOL *bool `json:"isBYOL,omitempty"`
-	// Specify if high performance storage should be used for the Database Cloud Service instance. Default data storage will allocate your database
-	// block storage on spinning devices. By checking this box, your block storage will be allocated on solid state devices. Valid values are true and false.
-	// Default value is false.
-	// Optional
-	UseHighPerformanceStorage bool `json:"useHighPerformanceStorage,omitempty"`
+	// Required. (Not required for Exadata)
+	VMPublicKey string `json:"vmPublicKeyText,omitempty"`
 }
 
 // StandBy specifies the standby attributes for a database service instance
@@ -522,6 +556,12 @@ type ParameterInput struct {
 	// Default value is AL16UTF16.
 	// Optional.
 	NCharSet ServiceInstanceNCharSet `json:"ncharset,omitempty"`
+	// Name for the Oracle Home directory location that you want to use for the database deployment.
+	// If you specify the name for an existing Oracle Home directory location, then the database
+	// deployment shares the existing Oracle Database binaries at that location. Otherwise a new
+	// Oracle Home is created.
+	// Optional. Exadata Cloud Service only
+	OracleHomeName string `json:"oracleHomeName,omitempty"`
 	// Note: This attribute is valid when Database Cloud Service instance is configured with version 12c.
 	// Pluggable Database Name for the Database Cloud Service instance.
 	// Default value is pdb1.
@@ -568,8 +608,8 @@ type ParameterInput struct {
 	// Storage size for data (in GB). Minimum value is 15. Maximum value depends on the backup
 	// destination: if BOTH is specified, the maximum value is 1200; if OSS or NONE is specified,
 	// the maximum value is 2048.
-	// Required.
-	UsableStorage string `json:"usableStorage"`
+	// Optional.
+	UsableStorage string `json:"usableStorage,omitempty"`
 	// Specify if the given cloudStorageContainer is to be created if it does not already exist.
 	// Default value is false.
 	// Optional.
@@ -631,6 +671,23 @@ type AdditionalParameters struct {
 	// Indicates whether to include the Demos PDB
 	// Optional
 	DBDemo string `json:"db_demo,omitempty"`
+}
+
+// NetworkingInfo returned for Exadata Service Instances
+type NetworkingInfo struct {
+	AdminNetwork  string         `json:"admin_network"`
+	BackupNetwork string         `json:"backup_network"`
+	ClientNetwork string         `json:"client_network"`
+	Computes      []ComputesInfo `json:"computes"`
+	ScanIPs       []string       `json:"scan_ips"`
+}
+
+// ComputesInfo for the Exadata Service Instance Compute Nodes
+type ComputesInfo struct {
+	AdminIP   string `json:"admin_ip"`
+	ClientIP  string `json:"client_ip"`
+	Hostname  string `json:"hostname"`
+	VirtualIP string `json:"virtual_ip"`
 }
 
 // CreateServiceInstance creates a new ServiceInstace.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -276,12 +276,12 @@
 			"versionExact": "v0.13.0"
 		},
 		{
-			"checksumSHA1": "9FX6D92J55zJrzkZOq8kowNpUzk=",
+			"checksumSHA1": "6qqjlC31LVdZEeEK7svUqv2WklI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "0883d7366b29235ab79f74fe3e9d49edf8d0f796",
-			"revisionTime": "2018-09-07T14:35:30Z",
-			"version": "v0.13.0",
-			"versionExact": "v0.13.0"
+			"revision": "38658ee17daf51e5afcdcd3f402251b0f67ba3fd",
+			"revisionTime": "2018-10-01T21:00:33Z",
+			"version": "v0.14.0",
+			"versionExact": "v0.14.0"
 		},
 		{
 			"checksumSHA1": "HVhKKQ6jpg3W9/MspUD09Xka238=",

--- a/website/docs/d/oraclepaas_database_compute_nodes.html.markdown
+++ b/website/docs/d/oraclepaas_database_compute_nodes.html.markdown
@@ -17,7 +17,7 @@ data "oraclepaas_database_compute_nodes" "foo" {
   name = "database-service-instance-1"
 }
 
-output "region" {
+output "compute_nodes" {
   value = "${data.oraclepaas_database_compute_nodes.foo.compute_nodes}"
 }
 ```

--- a/website/docs/d/oraclepaas_database_compute_nodes.html.markdown
+++ b/website/docs/d/oraclepaas_database_compute_nodes.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "oraclepaas"
+page_title: "Oracle: oraclepaas_database_compute_nodes"
+sidebar_current: "docs-oraclepaas-datasource-database-compute_nodes"
+description: |-
+  Gets information about the configuration of the Compute Nodes for a Oracle Database Cloud Service or Exadata Classic Cloud Service instance on the Oracle Cloud Platform.
+---
+
+# oraclepaas\_database\_compute\_nodes
+
+Use this data source to access the details of the individual Compute Nodes of a Database Service Instance
+
+## Example Usage
+
+```hcl
+data "oraclepaas_database_compute_nodes" "foo" {
+  name = "database-service-instance-1"
+}
+
+output "region" {
+  value = "${data.oraclepaas_database_compute_nodes.foo.compute_nodes}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Database Service Instance
+
+## Attributes Reference
+
+* `compute_nodes` - List of compute nodes for the Database Cloud Service instance, see [Compute Node attributes](#compute-node-attributes)
+
+
+### Compute Node attributes
+
+
+* `connect_descriptor` - The connection descriptor for Oracle Net Services (SQL*Net).
+
+* `connect_descriptor_with_public_ip` - The connection descriptor for Oracle Net Services (SQL*Net) with IP addresses instead of host names.
+
+* `hostname` - The host name of the compute node.
+
+* `initial_primary` - Indicates whether the compute node hosted the primary database of an Oracle Data Guard configuration when the service instance was created.
+
+* `listener_port` - The listener port for Oracle Net Services (SQL*Net) connections.
+
+* `pdb_name` - The name of the default PDB (pluggable database) created when the service instance was created.
+
+* `reserved_ip` - The IP address of the compute node.
+
+* `shape` - The Oracle Compute Cloud shape of the compute node.
+
+* `sid` - The SID of the database on the compute node.
+
+* `status` - The status of the compute node.
+
+* `storage_allocated` - The size in GB of the storage allocated to the compute node. For compute nodes of a service instance hosting an Oracle RAC database, this number does not include the storage shared by the nodes

--- a/website/oraclepaas.erb
+++ b/website/oraclepaas.erb
@@ -14,6 +14,9 @@
                         <li<%= sidebar_current("docs-oraclepaas-datasource-database-service-instance") %>>
                             <a href="/docs/providers/oraclepaas/d/oraclepaas_database_service_instance.html">oraclepaas_database_service_instance</a>
                         </li>
+                        <li<%= sidebar_current("docs-oraclepaas-datasource-database-compute-nodes") %>>
+                            <a href="/docs/providers/oraclepaas/d/oraclepaas_database_compute_nodes.html">oraclepaas_database_compute_nodes</a>
+                        </li>
                     </ul>
                 </li>
                 <li<%= sidebar_current("docs-oraclepaas-resource") %>>
@@ -33,7 +36,7 @@
                         </li>
                         <li<%= sidebar_current("docs-oraclepaas-resource-database-access-rule") %>>
                             <a href="/docs/providers/oraclepaas/r/oraclepaas_database_access_rule.html">oraclepaas_database_access_rule</a>
-                        </li>                        
+                        </li>
                         <li<%= sidebar_current("docs-oraclepaas-resource-java-access-rule") %>>
                             <a href="/docs/providers/oraclepaas/r/oraclepaas_java_access_rule.html">oraclepaas_java_access_rule</a>
                         </li>


### PR DESCRIPTION
Adds a new `oraclepaas_database_compute_nodes` datasource to retrieve the details of the individual compute nodes of a database cloud service instance.  Supports DBCS on OCI-Classic, OCI and ExaCS