### PR TITLE
Allowing for connect_string to be used in place of database.name

### DIFF
--- a/oraclepaas/resource_java_service_instance.go
+++ b/oraclepaas/resource_java_service_instance.go
@@ -281,7 +281,7 @@ func resourceOraclePAASJavaServiceInstance() *schema.Resource {
 									},
 									"name": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 										ForceNew: true,
 									},
 									"hostname": {
@@ -1057,7 +1057,9 @@ func expandDB(webLogicServer *java.CreateWLS, config map[string]interface{}) {
 	}
 
 	attrs := dbaInfo[0].(map[string]interface{})
-	webLogicServer.DBServiceName = attrs["name"].(string)
+	if attrs["name"].(string) != "" {
+		webLogicServer.DBServiceName = attrs["name"].(string)
+	}
 	webLogicServer.DBAName = attrs["username"].(string)
 	webLogicServer.DBAPassword = attrs["password"].(string)
 	if v := attrs["pdb_name"]; v != nil {

--- a/vendor/github.com/hashicorp/go-oracle-terraform/java/service_instance.go
+++ b/vendor/github.com/hashicorp/go-oracle-terraform/java/service_instance.go
@@ -1238,8 +1238,8 @@ type CreateWLS struct {
 	// 	deployment for your Oracle Java Cloud Service instance on Oracle Cloud Infrastructure.
 	//
 	// 	An Oracle Database Cloud Service database deployment based on a RAC database is also not supported.
-	// Required
-	DBServiceName string `json:"dbServiceName"`
+	// Optional
+	DBServiceName string `json:"dbServiceName,omitempty"`
 	// Mode of the domain. Valid values include: DEVELOPMENT and PRODUCTION. The default value is PRODUCTION.
 	// Optional
 	DomainMode ServiceInstanceDomainMode `json:"domainMode,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -352,58 +352,58 @@
 		{
 			"checksumSHA1": "gr7SCieiSg/tWyz2RWV1aM5+5sE=",
 			"path": "github.com/hashicorp/go-oracle-terraform/application",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "2HXZQWsVNPQme21DBmz9P3n9NNc=",
 			"path": "github.com/hashicorp/go-oracle-terraform/client",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "6qqjlC31LVdZEeEK7svUqv2WklI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/database",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "HVhKKQ6jpg3W9/MspUD09Xka238=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
-			"checksumSHA1": "BxfYgC/J8n7BgOBuCnc+hE6abx4=",
+			"checksumSHA1": "ovwcYLWqBsSlJ6LDbAcBBM2U860=",
 			"path": "github.com/hashicorp/go-oracle-terraform/java",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "QlqEBz8C87bNTuip9ihnxuWwicw=",
 			"path": "github.com/hashicorp/go-oracle-terraform/mysql",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "aeXObRk6gAfuvnT+puKaEib7dm0=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "dc6bd037d49de73648a9e99770e792b701c44f95",
-			"revisionTime": "2018-12-04T06:05:03Z",
-			"version": "v0.15.1",
-			"versionExact": "v0.15.1"
+			"revision": "6555b6a0d2f95f1d09985f85aef6366bea9de114",
+			"revisionTime": "2019-01-22T23:31:58Z",
+			"version": "v0.15.3",
+			"versionExact": "v0.15.3"
 		},
 		{
 			"checksumSHA1": "jjwWJ71TtQ3ibvPI7zcWcjZTnKs=",

--- a/website/docs/r/oraclepaas_java_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_java_service_instance.html.markdown
@@ -248,7 +248,7 @@ Database supports the following:
 
 * `password` - (Required) Password for the database administrator.
 
-* `name` - (Required) Name of the database on the Database Cloud Service.
+* `name` - (Optional) Name of the database on the Database Cloud Service.
 
 * `hostname` - (Computed) The hostname for the database.
 


### PR DESCRIPTION
This PR is to address this [issue](https://github.com/hashicorp/go-oracle-terraform/issues/178) around not being able to specify `connect_string` 