### PR TITLE
Add subcategories to docs for Terraform Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 - make test
 - make vet
 - make website-test
+- make test-docscheck
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,6 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -57,5 +56,8 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
+test-docscheck:
+	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
+
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test test-docscheck
 

--- a/scripts/docscheck.sh
+++ b/scripts/docscheck.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+docs=$(ls website/docs/**/*.markdown)
+error=false
+
+for doc in $docs; do
+  dirname=$(dirname "$doc")
+  category=$(basename "$dirname")
+
+
+  case "$category" in
+    "guides")
+      # Guides require a page_title
+      if ! grep "^page_title: " "$doc" > /dev/null; then
+        echo "Guide is missing a page_title: $doc"
+        error=true
+      fi
+      ;;
+
+    "d" | "r")
+      # Resources and data sources require a subcategory
+      if ! grep "^subcategory: " "$doc" > /dev/null; then
+        echo "Doc is missing a subcategory: $doc"
+        error=true
+      fi
+      ;;
+
+    *)
+      error=true
+      echo "Unknown category \"$category\". " \
+        "Docs can only exist in r/, d/, or guides/ folders."
+      ;;
+  esac
+done
+
+if $error; then
+  exit 1
+fi
+
+exit 0

--- a/website/docs/d/oraclepaas_database_service_instance.html.markdown
+++ b/website/docs/d/oraclepaas_database_service_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_service_instance"
 sidebar_current: "docs-oraclepaas-datasource-database-service-instance"

--- a/website/docs/r/oraclepaas_application_container.html.markdown
+++ b/website/docs/r/oraclepaas_application_container.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_application_container"
 sidebar_current: "docs-oraclepaas-resource-application-container"

--- a/website/docs/r/oraclepaas_database_access_rule.html.markdown
+++ b/website/docs/r/oraclepaas_database_access_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_access_rule"
 sidebar_current: "docs-oraclepaas-resource-access-rule"

--- a/website/docs/r/oraclepaas_database_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_database_service_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_database_service_instance"
 sidebar_current: "docs-oraclepaas-resource-service-instance"

--- a/website/docs/r/oraclepaas_java_access_rule.html.markdown
+++ b/website/docs/r/oraclepaas_java_access_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_java_access_rule"
 sidebar_current: "docs-oraclepaas-resource-access-rule"

--- a/website/docs/r/oraclepaas_java_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_java_service_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_java_service_instance"
 sidebar_current: "docs-oraclepaas-resource-service-instance"

--- a/website/docs/r/oraclepaas_mysql_access_rule.html.markdown
+++ b/website/docs/r/oraclepaas_mysql_access_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: oraclepaas_mysql_access_rule"
 sidebar_current: "docs-oraclepaas-resource-access-rule"

--- a/website/docs/r/oraclepaas_mysql_service_instance.html.markdown
+++ b/website/docs/r/oraclepaas_mysql_service_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "PaaS"
 layout: "oraclepaas"
 page_title: "Oracle: mysql_service_instance"
 sidebar_current: "docs-oraclepaas-resource-service-instance"


### PR DESCRIPTION
* Add subcategories to docs for Terraform Registry

We will soon be displaying documentation for this provider both on
[terraform.io](https://www.terraform.io/docs/providers/index.html)
and on [the Terraform Registry](https://registry.terraform.io/providers).

Documentation displayed on the Terraform Registry will not use the ERB
layout containing the existing navigation, and will instead build the
navigation dynamically based on the directory and YAML frontmatter of a file.
For providers that group similar resources and data sources by service or
use case (subcategories), we'll need to add this information to the
Markdown source file.

This PR modifies Resource and Data Source documentation source files by
adding a subcategory to the metadata if those files were grouped previously.

For more information about how documentation is rendered on the
Terraform Registry, please see this reference:
[Terraform Registry - Provider Documentation](https://www.terraform.io/docs/registry/providers/docs.html).

* Add Docs Check Script

Add script to check docs compatibility with Terraform Registry
importing.